### PR TITLE
feat: Implement blog post series feature

### DIFF
--- a/src/content/blog/01-welcome-to-my-blog/index.md
+++ b/src/content/blog/01-welcome-to-my-blog/index.md
@@ -2,6 +2,8 @@
 title: "Welcome to my blog"
 description: "Basic rant on what I would use this blog for."
 date: "Jan 21 2025"
+seriesId: "getting-started-with-astro"
+seriesOrder: 1
 ---
 
 Hey!

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,7 +6,9 @@ const blog = defineCollection({
     title: z.string(),
     description: z.string(),
     date: z.coerce.date(),
-    draft: z.boolean().optional()
+    draft: z.boolean().optional(),
+    seriesId: z.string().optional(),
+    seriesOrder: z.number().optional()
   }),
 });
 
@@ -32,4 +34,13 @@ const projects = defineCollection({
   }),
 });
 
-export const collections = { blog, work, projects };
+const series = defineCollection({
+  schema: z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    order: z.number().optional(),
+  }),
+});
+
+export const collections = { blog, work, projects, series };

--- a/src/content/series/getting-started-with-astro.md
+++ b/src/content/series/getting-started-with-astro.md
@@ -1,0 +1,7 @@
+---
+id: "getting-started-with-astro"
+title: "Getting Started with Astro"
+description: "A beginner-friendly series on learning Astro."
+order: 1
+---
+This series will walk you through the basics of Astro.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,6 +19,56 @@ type Props = CollectionEntry<"blog">;
 
 const post = Astro.props;
 const { Content } = await post.render();
+
+// Series data fetching logic
+import { getEntry } from "astro:content"; // getCollection is already imported
+
+let seriesEntry = null;
+let seriesPosts = [];
+let previousPost = null;
+let nextPost = null;
+
+if (post.data.seriesId) {
+  try {
+    // getEntry might return undefined if not found, or throw.
+    // The example uses await getEntry("series", post.data.seriesId)
+    // It's safer to assign directly and check for null/undefined.
+    const entry = await getEntry("series", post.data.seriesId);
+    if (entry) {
+      seriesEntry = entry;
+    } else {
+      console.warn(`Series with id "${post.data.seriesId}" not found for post "${post.slug}".`);
+    }
+  } catch (e) {
+    // Catch if getEntry throws for some reason (e.g. invalid ID format)
+    console.error(`Error fetching series with id "${post.data.seriesId}" for post "${post.slug}":`, e);
+  }
+  
+  if (seriesEntry) {
+    seriesPosts = (await getCollection("blog"))
+      .filter(p => !p.data.draft && p.data.seriesId === post.data.seriesId)
+      .sort((a, b) => {
+        const orderA = a.data.seriesOrder ?? Infinity;
+        const orderB = b.data.seriesOrder ?? Infinity;
+        // If order is the same, or both are Infinity, maintain original sort (date) or add secondary sort if needed
+        if (orderA === orderB) {
+            return new Date(a.data.date).getTime() - new Date(b.data.date).getTime(); // Older first for series posts
+        }
+        return orderA - orderB;
+      });
+    
+    const currentIndex = seriesPosts.findIndex(p => p.slug === post.slug);
+    
+    if (currentIndex !== -1) { // Ensure post is found in series (it should be)
+      if (currentIndex > 0) {
+        previousPost = seriesPosts[currentIndex - 1];
+      }
+      if (currentIndex < seriesPosts.length - 1) {
+        nextPost = seriesPosts[currentIndex + 1];
+      }
+    }
+  }
+}
 ---
 
 <PageLayout title={post.data.title} description={post.data.description}>
@@ -41,9 +91,37 @@ const { Content } = await post.render();
       <div class="animate text-2xl font-semibold text-black dark:text-white">
         {post.data.title}
       </div>
+      <!-- Series Link -->
+      {seriesEntry && (
+        <div class="animate font-base text-sm text-gray-700 dark:text-gray-300">
+          Part of series: <a href={`/series/${seriesEntry.id}`} class="text-blue-600 dark:text-blue-400 hover:underline">{seriesEntry.data.title}</a>
+        </div>
+      )}
     </div>
     <article class="animate">
       <Content />
     </article>
+
+    <!-- Series Navigation -->
+    {seriesEntry && (previousPost || nextPost) && (
+      <nav class="animate mt-10 pt-6 border-t border-gray-200 dark:border-gray-700 flex flex-col sm:flex-row sm:justify-between gap-4">
+        <div>
+          {previousPost && (
+            <a href={`/blog/${previousPost.slug}`} class="block text-blue-600 dark:text-blue-400 hover:underline text-left">
+              <span class="text-sm text-gray-600 dark:text-gray-400">&laquo; Previous in series:</span>
+              <span class="block font-medium">{previousPost.data.title}</span>
+            </a>
+          )}
+        </div>
+        <div class="sm:text-right">
+          {nextPost && (
+            <a href={`/blog/${nextPost.slug}`} class="block text-blue-600 dark:text-blue-400 hover:underline text-left sm:text-right">
+              <span class="text-sm text-gray-600 dark:text-gray-400">Next in series: &raquo;</span>
+              <span class="block font-medium">{nextPost.data.title}</span>
+            </a>
+          )}
+        </div>
+      </nav>
+    )}
   </Container>
 </PageLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,17 +4,36 @@ import PageLayout from "@layouts/PageLayout.astro";
 import Container from "@components/Container.astro";
 import ArrowCard from "@components/ArrowCard.astro";
 import { BLOG } from "@consts";
+// getEntry is not strictly needed if we fetch all series once with getCollection
+// import { type CollectionEntry, getCollection, getEntry } from "astro:content"; 
 
-const data = (await getCollection("blog"))
+const allPostsData = (await getCollection("blog"))
   .filter(post => !post.data.draft)
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
-  
+
+// Fetch all series to create a lookup map
+const seriesEntries = await getCollection("series");
+const seriesTitleMap = new Map(seriesEntries.map(s => [s.id, s.data.title]));
+
+// Enhance posts with series title
+const postsWithSeriesInfo = allPostsData.map(post => {
+  let seriesTitle = null;
+  if (post.data.seriesId && seriesTitleMap.has(post.data.seriesId)) {
+    seriesTitle = seriesTitleMap.get(post.data.seriesId);
+  }
+  return { ...post, seriesTitle }; // Add seriesTitle to the post object
+});
+
+// Now, group postsWithSeriesInfo by year
+// The post type now includes an optional seriesTitle at the top level
+type PostWithSeriesTitle = CollectionEntry<"blog"> & { seriesTitle?: string | null };
+
 type Acc = {
-  [year: string]: CollectionEntry<"blog">[];
+  [year: string]: PostWithSeriesTitle[];
 }
 
-const posts = data.reduce((acc: Acc, post) => {
-    const year = post.data.date.getFullYear().toString();
+const postsByYear = postsWithSeriesInfo.reduce((acc: Acc, post) => {
+    const year = post.data.date.getFullYear().toString(); // post.data.date should be correct here
     if (!acc[year]) {
       acc[year] = [];
     }
@@ -22,7 +41,7 @@ const posts = data.reduce((acc: Acc, post) => {
     return acc;
   }, {});
 
-const years = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a)); 
+const years = Object.keys(postsByYear).sort((a, b) => parseInt(b) - parseInt(a)); 
 ---
 
 <PageLayout title={BLOG.TITLE} description={BLOG.DESCRIPTION}>
@@ -40,9 +59,14 @@ const years = Object.keys(posts).sort((a, b) => parseInt(b) - parseInt(a));
             <div>
               <ul class="flex flex-col gap-4">
                 {
-                  posts[year].map((post) => (
+                  postsByYear[year].map((post) => ( // Use postsByYear here
                     <li>
-                      <ArrowCard entry={post}/>
+                      <ArrowCard entry={post} />
+                      {post.seriesTitle && (
+                        <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          Part of series: <a href={`/series/${post.data.seriesId}`} class="text-blue-600 dark:text-blue-400 hover:underline">{post.seriesTitle}</a>
+                        </div>
+                      )}
                     </li>
                   ))
                 }

--- a/src/pages/series/[id].astro
+++ b/src/pages/series/[id].astro
@@ -1,0 +1,65 @@
+---
+import { type CollectionEntry, getCollection } from "astro:content";
+import PageLayout from "@layouts/PageLayout.astro";
+import Container from "@components/Container.astro";
+import ArrowCard from "@components/ArrowCard.astro";
+import BackToPrev from "@components/BackToPrev.astro";
+
+export async function getStaticPaths() {
+  const seriesEntries = await getCollection("series");
+  return seriesEntries.map((series) => ({
+    params: { id: series.id }, // Use series.id for the slug
+    props: { series }, // Pass the full series entry as a prop
+  }));
+}
+
+interface Props {
+  series: CollectionEntry<"series">;
+}
+
+const { series } = Astro.props;
+
+// Fetch all blog posts and filter/sort them for this series
+const allPosts = await getCollection("blog");
+const seriesPosts = allPosts
+  .filter(post => !post.data.draft && post.data.seriesId === series.id)
+  .sort((a, b) => {
+    const orderA = a.data.seriesOrder ?? Infinity;
+    const orderB = b.data.seriesOrder ?? Infinity;
+    if (orderA === orderB) {
+      // If order is the same, or both are Infinity, sort by date
+      return new Date(b.data.date).getTime() - new Date(a.data.date).getTime();
+    }
+    return orderA - orderB;
+  });
+---
+
+<PageLayout title={series.data.title} description={series.data.description}>
+  <Container>
+    <div class="animate">
+      <BackToPrev href="/series">
+        Back to all series
+      </BackToPrev>
+    </div>
+
+    <div class="my-10 space-y-4">
+      <h1 class="animate text-3xl font-bold text-black dark:text-white">{series.data.title}</h1>
+      <p class="animate text-lg text-gray-700 dark:text-gray-300">{series.data.description}</p>
+    </div>
+
+    <div class="space-y-4">
+      <h2 class="animate text-2xl font-semibold text-black dark:text-white">Posts in this series:</h2>
+      {seriesPosts.length > 0 ? (
+        <ul class="animate flex flex-col gap-4">
+          {seriesPosts.map((post) => (
+            <li>
+              <ArrowCard entry={post} />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p class="animate text-gray-700 dark:text-gray-300">No posts in this series yet. If you've added posts, ensure they have the correct 'seriesId' and are not marked as 'draft'.</p>
+      )}
+    </div>
+  </Container>
+</PageLayout>

--- a/src/pages/series/index.astro
+++ b/src/pages/series/index.astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from "astro:content";
+import PageLayout from "@layouts/PageLayout.astro";
+import Container from "@components/Container.astro";
+import ArrowCard from "@components/ArrowCard.astro";
+
+// Fetch all series, sort by order, then by title
+const seriesEntries = (await getCollection("series")).sort((a, b) => {
+  const orderA = a.data.order ?? Infinity;
+  const orderB = b.data.order ?? Infinity;
+  if (orderA !== orderB) {
+    return orderA - orderB;
+  }
+  return a.data.title.localeCompare(b.data.title);
+});
+---
+
+<PageLayout title="Blog Series" description="Browse blog post series.">
+  <Container>
+    <div class="space-y-10">
+      <div class="animate text-2xl font-bold text-black dark:text-white">
+        Blog Series
+      </div>
+      <div class="space-y-4">
+        <section class="animate space-y-4">
+          <div>
+            <ul class="flex flex-col gap-4">
+              {
+                seriesEntries.map((seriesItem) => (
+                  <li>
+                    <ArrowCard entry={{ slug: `series/${seriesItem.id}`, data: seriesItem.data }} />
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  </Container>
+</PageLayout>


### PR DESCRIPTION
This commit introduces a new "series" functionality to the blog. You can now group related blog posts into a series, view a list of all series, and navigate through posts within a specific series.

Key changes include:

1.  **Content Schema Updates (`src/content/config.ts`):**
    *   Added a new `series` collection with fields for `id`, `title`, `description`, and `order`.
    *   Extended the `blog` collection schema to include `seriesId` (to link to a series) and `seriesOrder` (for post order within a series).

2.  **New Content and Pages:**
    *   Created `src/content/series/` directory with an example series `getting-started-with-astro.md`.
    *   Added `src/pages/series/index.astro` to list all available series.
    *   Added `src/pages/series/[id].astro` as a dynamic page to display individual series information and list its associated blog posts in order.

3.  **Enhancements to Existing Blog Pages:**
    *   `src/pages/blog/[...slug].astro` (Individual Post Page):
        *   Displays a "Part of series: [Series Title]" link if the post belongs to a series.
        *   Adds "Next" and "Previous" navigation links for posts within the same series.
    *   `src/pages/blog/index.astro` (Blog Index Page):
        *   Indicates when a listed post is part of a series and provides a link to that series.

4.  **Styling:**
    *   Applied styling consistent with the existing website design, ensuring responsiveness and dark mode compatibility for all new UI elements.

An example blog post (`01-welcome-to-my-blog/index.md`) was updated to demonstrate its inclusion in a sample series. No new tests were added as no existing testing infrastructure was identified.